### PR TITLE
Add query param support (starting with orders)

### DIFF
--- a/modules/PactResource.js
+++ b/modules/PactResource.js
@@ -7,6 +7,7 @@ const basicMethods = {
   // List records from the API
   list: pactMethod({
     method: methodTypes.GET,
+    queryParams: ['page', 'per_page'],
   }),
   // Retrieve a specific record from the API
   retrieve: pactMethod({

--- a/modules/resources/Orders.js
+++ b/modules/resources/Orders.js
@@ -1,15 +1,24 @@
 import PactResource from '../PactResource';
+import pactMethod from '../pactMethod';
+import methodTypes from '../methodTypes';
 
 export default class Orders extends PactResource {
   constructor(pactAPI) {
     const path = '/users/me/orders';
     const includeBasic = [
-      'list',
       'retrieve',
       'create',
       'update',
       'del',
     ];
-    super({pactAPI, path, includeBasic});
+
+    const methods = {
+      list: pactMethod({
+        method: methodTypes.GET,
+        queryParams: ['states', 'per_page', 'page'],
+      }),
+    };
+
+    super({pactAPI, path, includeBasic, methods});
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "invariant": "^2.1.0",
+    "qs": "^5.2.0",
     "superagent": "^1.2.0"
   }
 }

--- a/test/pactMethod-test.js
+++ b/test/pactMethod-test.js
@@ -36,7 +36,7 @@ describe('pactMethod', () => {
       method: 'patch',
     });
     mockPactResource.mock();
-    assert.ok(spy.calledWith('patch', 'testPath/'));
+    assert.ok(spy.calledWith('patch', 'testPath'));
   });
 
   it('Accepts a relative "path" argument, building the correct URL', () => {
@@ -79,7 +79,7 @@ describe('pactMethod', () => {
       ));
     });
 
-    it('Throws if a urlParam is requried but not passed in the payload', () => {
+    it('Throws if a urlParam is required but not passed in the payload', () => {
       const spy = sinon.spy();
       const mockPactResource = {
         _request: spy,
@@ -94,7 +94,7 @@ describe('pactMethod', () => {
       assert.throws(() => mockPactResource.mock({}));
     });
 
-    it('Leaves the rest of the payload alone', () => {
+    it('Leaves the rest of the payload alone, passing it into the request', () => {
       const spy = sinon.spy();
       const mockPactResource = {
         _request: spy,
@@ -111,6 +111,28 @@ describe('pactMethod', () => {
         'post',
         'testPath/testId',
         {foo: 'bar'}
+      ));
+    });
+  });
+
+  describe('"queryParams" argument', () => {
+    it('Are optional');
+    it('Interpolates query params from the payload', () => {
+      const spy = sinon.spy();
+
+      const mockPactResource = {
+        _request: spy,
+        path: 'testPath',
+      };
+
+      mockPactResource.mock = pactMethod({
+        method: 'get',
+        queryParams: ['foo', 'bar'],
+      });
+      mockPactResource.mock({foo: 'baz', bar: 'qux'});
+      assert.ok(spy.calledWith(
+        'get',
+        'testPath?foo=baz&bar=qux'
       ));
     });
   });


### PR DESCRIPTION
# What?

Now when calling specific viper methods, you can pass whitelisted query parameters in the payload:
```js
viper.orders.list({state: ['current', 'billed'], page: 2, per_page: 10});
```

# How?

When defining your resource methods, pass `queryParams` to the `pactMethod` function:
```js
const methods = {
      someMethod: pactMethod({
        method: methodTypes.GET,
        queryParams: ['a bunch of optional params'],
      }),
    };
```

### Please note:
- Query params defined on a method will whitelist those keys. Be careful not to conflict with those key names
- Params are optional by nature