### PR TITLE
Format querystring arrays correctly

### DIFF
--- a/modules/pactMethod.js
+++ b/modules/pactMethod.js
@@ -6,7 +6,11 @@ import methodTypes from './methodTypes';
 function buildURL(base, path, queryObj) {
   let fullPath;
   if (Object.keys(queryObj).length) {
-    fullPath = `${base}${path ? '/' + path : ''}?${qs.stringify(queryObj)}`;
+    const query = qs.stringify(queryObj, {
+      arrayFormat: 'brackets',
+      encode: false,
+    });
+    fullPath = `${base}${path ? '/' + path : ''}?${query}`;
   } else {
     fullPath = `${base}${path ? '/' + path : ''}`;
   }


### PR DESCRIPTION
`orders?states%5B0%5D=shipped&per_page=10&page=1`
becomes
`orders?states[]=shipped&per_page=10&page=1`

for compatibility with viper