### PR TITLE
resetDeclinedCard method

### DIFF
--- a/modules/resources/Users.js
+++ b/modules/resources/Users.js
@@ -27,7 +27,7 @@ export default class Users extends PactResource {
         path: '{user_id}/email',
       }),
 
-      updatePayment: pactMethod({
+      updateCard: pactMethod({
         method: methodTypes.PATCH,
         urlParams: ['user_id'],
         path: '{user_id}/card',

--- a/modules/resources/Users.js
+++ b/modules/resources/Users.js
@@ -33,6 +33,12 @@ export default class Users extends PactResource {
         path: '{user_id}/card',
       }),
 
+      resetDeclinedCard: pactMethod({
+        method: methodTypes.PATCH,
+        urlParams: ['user_id'],
+        path: '{user_id}/card/reset',
+      }),
+
       applyVoucher: pactMethod({
         method: methodTypes.POST,
         urlParams: ['user_id'],


### PR DESCRIPTION
Preemptive method for wrapping Viper's reset card end point. Provisionally going to hit `/v1/users/{user_id}/card/reset`, but is waiting @chrisspang starting work on the [Viper handling declined payments](https://trello.com/c/Tbg8fML1/57-declined-payments-workflow) for finalisation.