### PR TITLE
Add PasswordReset resource & methods

### DIFF
--- a/modules/PactAPI.js
+++ b/modules/PactAPI.js
@@ -1,3 +1,4 @@
+import PasswordReset from './resources/PasswordReset';
 import Recurrables from './resources/Recurrables';
 import OrderItems from './resources/OrderItems';
 import Identities from './resources/Identities';
@@ -12,6 +13,7 @@ import Users from './resources/Users';
 import Ping from './resources/Ping';
 
 const resources = {
+  PasswordReset,
   Recurrables,
   OrderItems,
   Identities,

--- a/modules/pactMethod.js
+++ b/modules/pactMethod.js
@@ -23,6 +23,7 @@ export default function pactMethod({
   path = '',
   urlParams = [],
   queryParams = [],
+  payloadParams = [],
 }) {
   const pathGenerator = makeURLInterpolator(path);
 
@@ -30,6 +31,17 @@ export default function pactMethod({
     const urlData = {};
     const queryData = {};
 
+    // Check if the payload contains the required payloadParams
+    payloadParams.forEach(param => {
+      const value = payload[param];
+      if (typeof value === 'undefined') {
+        throw new Error(
+          `PactAPI: I require a payload containing "${param}"}`
+        );
+      }
+    });
+
+    // Pull out query params from the payload
     queryParams.forEach(param => {
       const value = payload[param];
 
@@ -39,7 +51,7 @@ export default function pactMethod({
       }
     });
 
-    // Check to see if we have all the arguments we require
+    // Build the URL and check we have the required urlParams
     urlParams.forEach(param => {
       const required = payload[param];
       if (typeof required === 'undefined' || required === null) {

--- a/modules/pactMethod.js
+++ b/modules/pactMethod.js
@@ -31,16 +31,6 @@ export default function pactMethod({
     const urlData = {};
     const queryData = {};
 
-    // Check if the payload contains the required payloadParams
-    payloadParams.forEach(param => {
-      const value = payload[param];
-      if (typeof value === 'undefined') {
-        throw new Error(
-          `PactAPI: I require a payload containing "${param}"}`
-        );
-      }
-    });
-
     // Pull out query params from the payload
     queryParams.forEach(param => {
       const value = payload[param];
@@ -65,6 +55,16 @@ export default function pactMethod({
 
       // Remove it from the payload
       delete payload[param];
+    });
+
+    // Check if the payload contains the required payloadParams
+    payloadParams.forEach(param => {
+      const value = payload[param];
+      if (typeof value === 'undefined') {
+        throw new Error(
+          `PactAPI: I require a payload containing "${param}"}`
+        );
+      }
     });
 
     const resourcePath = this.path;

--- a/modules/resources/PasswordReset.js
+++ b/modules/resources/PasswordReset.js
@@ -9,11 +9,11 @@ export default class PasswordReset extends PactResource {
     const methods = {
       sendEmail: pactMethod({
         method: methodTypes.POST,
-        // payload: {email}
+        payloadParams: ['email'],
       }),
       setNewPassword: pactMethod({
         method: methodTypes.PATCH,
-        // payload: {password_reset_token, new_password}
+        payloadParams: ['password_reset_token', 'new_password'],
       }),
     };
 

--- a/modules/resources/PasswordReset.js
+++ b/modules/resources/PasswordReset.js
@@ -1,0 +1,22 @@
+import PactResource from '../PactResource';
+import pactMethod from '../pactMethod';
+import methodTypes from '../methodTypes';
+
+export default class PasswordReset extends PactResource {
+  constructor(pactAPI) {
+    const path = '/password_reset';
+
+    const methods = {
+      sendEmail: pactMethod({
+        method: methodTypes.POST,
+        // payload: {email}
+      }),
+      setNewPassword: pactMethod({
+        method: methodTypes.PATCH,
+        // payload: {password_reset_token, new_password}
+      }),
+    };
+
+    super({pactAPI, path, methods});
+  }
+}

--- a/test/PactAPI-test.js
+++ b/test/PactAPI-test.js
@@ -86,6 +86,7 @@ describe('PactAPI', () => {
         'orders',
         'ping',
         'products',
+        'passwordReset',
         'recurrables',
         'token',
         'users',

--- a/test/pactMethod-test.js
+++ b/test/pactMethod-test.js
@@ -136,4 +136,41 @@ describe('pactMethod', () => {
       ));
     });
   });
+
+  describe('"payloadParams" argument', () => {
+    it('Are required', () => {
+      const spy = sinon.spy();
+
+      const mockPactResource = {
+        _request: spy,
+        path: 'testPath',
+      };
+
+      mockPactResource.mock = pactMethod({
+        method: 'get',
+        payloadParams: ['foo'],
+      });
+      assert.throws(() => mockPactResource.mock({}));
+    });
+
+    it('Interpolates payload params from the payload', () => {
+      const spy = sinon.spy();
+
+      const mockPactResource = {
+        _request: spy,
+        path: 'testPath',
+      };
+
+      mockPactResource.mock = pactMethod({
+        method: 'get',
+        payloadParams: ['foo', 'bar'],
+      });
+      mockPactResource.mock({foo: 'baz', bar: 'qux'});
+      assert.ok(spy.calledWith(
+        'get',
+        'testPath',
+        {foo: 'baz', bar: 'qux'}
+      ));
+    });
+  });
 });


### PR DESCRIPTION
# Depends on https://github.com/PactCoffee/viper/pull/393

- [x] Add method for sending a password reset token to the given email
- [x] Add method for setting the new password

Also adds a new array param for use inside `pactMethod`: `payloadParams`. Keys in this array must exist inside the payload.