### PR TITLE
Use `superagent-legacyIESupport` plugin

### DIFF
--- a/modules/PactResource.js
+++ b/modules/PactResource.js
@@ -1,4 +1,5 @@
 import request from 'superagent';
+import lolIE from 'superagent-legacyiesupport';
 
 import pactMethod from './pactMethod';
 import methodTypes from './methodTypes';
@@ -74,6 +75,7 @@ export default class PactResource {
 
     return new Promise((resolve, reject) => {
       const req = request[method](url);
+      req.use(lolIE);
       if (payload) {
         req.send(payload);
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "invariant": "^2.1.0",
     "qs": "^5.2.0",
-    "superagent": "^1.2.0"
+    "superagent": "^1.2.0",
+    "superagent-legacyiesupport": "^1.0.1"
   }
 }

--- a/test/PactResource-test.js
+++ b/test/PactResource-test.js
@@ -13,12 +13,12 @@ describe('PactResource', () => {
 
   const sendSpy = sinon.stub().returns(reqMethods);
   const authSpy = sinon.stub().returns(reqMethods);
-  const onSpy = sinon.stub().returns(reqMethods);
+  const useSpy = sinon.stub().returns(reqMethods);
   const endSpy = sinon.stub().returns(reqMethods);
 
   reqMethods.send = sendSpy;
   reqMethods.auth = authSpy;
-  reqMethods.on = onSpy;
+  reqMethods.use = useSpy;
   reqMethods.end = endSpy;
 
   describe('Constructor', () => {


### PR DESCRIPTION
Adds cross-domain legacy support to IE9