### PR TITLE
Add setRequestTimeout method

### DIFF
--- a/modules/PactAPI.js
+++ b/modules/PactAPI.js
@@ -61,6 +61,9 @@ export default class PactAPI {
       this._api.errorHandler = callback;
     }
   }
+  setRequestTimeout(ms) {
+    this._api.timeout = ms;
+  }
   _prepResources() {
     Object.keys(resources).forEach(name => {
       this[

--- a/modules/PactResource.js
+++ b/modules/PactResource.js
@@ -72,11 +72,15 @@ export default class PactResource {
     const version = this._pactAPI.getAPIField('version');
     const token = this._pactAPI.getAPIField('token');
     const errorHandler = this._pactAPI.getAPIField('errorHandler');
+    const timeout = this._pactAPI.getAPIField('timeout');
     const url = `${base}/${version}${path}`;
 
     return new Promise((resolve, reject) => {
       const req = request[method](url);
 
+      if (timeout) {
+        req.timeout(timeout);
+      }
       if (canUseDOM) {
         req.use(lolIE);
       }

--- a/test/PactResource-test.js
+++ b/test/PactResource-test.js
@@ -14,11 +14,13 @@ describe('PactResource', () => {
   const sendSpy = sinon.stub().returns(reqMethods);
   const authSpy = sinon.stub().returns(reqMethods);
   const useSpy = sinon.stub().returns(reqMethods);
+  const timeoutSpy = sinon.stub().returns(reqMethods);
   const endSpy = sinon.stub().returns(reqMethods);
 
   reqMethods.send = sendSpy;
   reqMethods.auth = authSpy;
   reqMethods.use = useSpy;
+  reqMethods.timeout = timeoutSpy;
   reqMethods.end = endSpy;
 
   describe('Constructor', () => {
@@ -150,6 +152,20 @@ describe('PactResource', () => {
       });
       instance._request('post', '/testPath');
       assert.ok(authSpy.called);
+    });
+
+    it('Uses a request timeout value if there is one', () => {
+      const fakes = {
+        timeout: 3000,
+      };
+      instance = new PactResource({
+        pactAPI: {
+          getAPIField: (key) => fakes[key],
+        },
+        path: mockPath,
+      });
+      instance._request('post', '/testPath');
+      assert.ok(timeoutSpy.called);
     });
 
     it('Calls the error handler if there is one');


### PR DESCRIPTION
Means we can set a short timeout on the server so the user's not waiting around for viper requests to come back.