### PR TITLE
Remove unused methods and query parameters

### DIFF
--- a/modules/resources/Products.js
+++ b/modules/resources/Products.js
@@ -10,16 +10,6 @@ export default class Products extends PactResource {
         method: methodTypes.GET,
         queryParams: ['sku', 'available', 'page', 'per_page'],
       }),
-      listBundles: pactMethod({
-        method: methodTypes.GET,
-        path: 'bundle',
-        queryParams: ['sku', 'available', 'page', 'per_page'],
-      }),
-      listHardwares: pactMethod({
-        method: methodTypes.GET,
-        path: 'hardware',
-        queryParams: ['sku', 'available', 'page', 'per_page'],
-      }),
       listCoffees: pactMethod({
         method: methodTypes.GET,
         path: 'coffee',
@@ -30,10 +20,6 @@ export default class Products extends PactResource {
           'best_for',
           'decaf',
           'limited',
-          'origin',
-          'producer',
-          'varietal',
-          'altitude',
           'page',
           'per_page',
         ],


### PR DESCRIPTION
Remove unused product methods and `listCoffees` query parameters. As per @chrisspang's request